### PR TITLE
Fix branch name detection for PR builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ before_script:
 script:
   - vendor/bin/php-cs-fixer fix --diff --dry-run
   - vendor/bin/phpunit
+
+after_script:
+  - env

--- a/src/Ci/Travis.php
+++ b/src/Ci/Travis.php
@@ -41,7 +41,13 @@ class Travis extends AbstractCi
 
     public function getGitBranch()
     {
-        return $this->env->get('TRAVIS_BRANCH');
+        if ($this->env->get('TRAVIS_PULL_REQUEST') === 'false') {
+            return $this->env->get('TRAVIS_BRANCH');
+        }
+
+        // If the build is for PR, return name of the branch with the PR, not the target PR branch
+        // https://github.com/travis-ci/travis-ci/issues/6652
+        return $this->env->get('TRAVIS_PULL_REQUEST_BRANCH');
     }
 
     public function getRepositoryUrl()

--- a/tests/phpt/CiDetector_TravisPullRequest.phpt
+++ b/tests/phpt/CiDetector_TravisPullRequest.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Detect branch name for pull request builds on Travis CI
+
+--ENV--
+CI=true
+CONTINUOUS_INTEGRATION=true
+TRAVIS=true
+TRAVIS_REPO_SLUG=OndraM/ci-detector
+HAS_ANTARES_THREE_LITTLE_FRONZIES_BADGE=true
+TRAVIS_PULL_REQUEST=333
+TRAVIS_COMMIT=fad3f7bdbf3515d1e9285b8aa80feeff74507bdd
+HAS_JOSH_K_SEAL_OF_APPROVAL=true
+TRAVIS_OS_NAME=linux
+TRAVIS_LANGUAGE=php
+TRAVIS_JOB_NUMBER=1.2
+TRAVIS_EVENT_TYPE=push
+TRAVIS_BUILD_ID=148395135
+TRAVIS_PHP_VERSION=7
+TRAVIS_BRANCH=master
+TRAVIS_COMMIT_RANGE=1a57e2b9204c^...fad3f7bdbf35
+TRAVIS_JOB_ID=148395137
+TRAVIS_BUILD_DIR=/home/travis/build/OndraM/ci-detector
+TRAVIS_BUILD_NUMBER=1
+TRAVIS_TAG=tag
+TRAVIS_PULL_REQUEST_BRANCH=test-travis-branch
+
+--FILE--
+<?php
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$ci = OndraM\CiDetector::detect();
+var_dump($ci->getGitBranch());
+
+--EXPECT--
+string(18) "test-travis-branch"


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/6652 and https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/.

For PR builds (= build where Travis will attempt to merge the PR to the target branch) the target name should still be reported as the one of the PR, not the target one.