### PR TITLE
BC: Move all classes to CiDetector sub-namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 - BC: The `detect()` method of `CiDetector` class is no longer static.
+- BC: Rearrange namespaces, all classes are now in `CiDetector` sub-namespace.
 
 ## 1.1.0 - 2017-01-06
 - Add `getGitBranch()` method to detect Git branch of the build (supported by all CIs except TeamCity).

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ $ composer require ondram/ci-detector
 ```php
 <?php
 
-$ci = (new OndraM\CiDetector())->detect(); // Will return false or instance implementing CiInterface
+$ci = (new OndraM\CiDetector\CiDetector())->detect(); // Will return false or instance implementing CiInterface
 
-if (!$ci instanceof OndraM\Ci\CiInterface) {
+if (!$ci instanceof OndraM\CiDetector\Ci\CiInterface) {
     // false is returned from the CiDetector::detect() method if CI server was not detected
     echo "CI not detected";
 } else {

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "OndraM\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "OndraM\\Tests\\": "tests/"
+            "OndraM\\CiDetector\\": "src/"
         }
     },
     "require": {

--- a/dump-current.php
+++ b/dump-current.php
@@ -4,9 +4,9 @@
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$ci = (new \OndraM\CiDetector())->detect();
+$ci = (new \OndraM\CiDetector\CiDetector())->detect();
 
-if ($ci instanceof \OndraM\Ci\CiInterface) {
+if ($ci instanceof \OndraM\CiDetector\Ci\CiInterface) {
     var_dump($ci->getCiName());
     var_dump($ci->getBuildNumber());
     var_dump($ci->getBuildUrl());

--- a/src/Ci/AbstractCi.php
+++ b/src/Ci/AbstractCi.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace OndraM\Ci;
+namespace OndraM\CiDetector\Ci;
 
-use OndraM\Env;
+use OndraM\CiDetector\Env;
 
 /**
  * Unified adapter to retrieve environment variables from current continuous integration server

--- a/src/Ci/Bamboo.php
+++ b/src/Ci/Bamboo.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OndraM\Ci;
+namespace OndraM\CiDetector\Ci;
 
-use OndraM\CiDetector;
-use OndraM\Env;
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
 
 class Bamboo extends AbstractCi
 {

--- a/src/Ci/CiInterface.php
+++ b/src/Ci/CiInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace OndraM\Ci;
+namespace OndraM\CiDetector\Ci;
 
-use OndraM\Env;
+use OndraM\CiDetector\Env;
 
 interface CiInterface
 {

--- a/src/Ci/Circle.php
+++ b/src/Ci/Circle.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OndraM\Ci;
+namespace OndraM\CiDetector\Ci;
 
-use OndraM\CiDetector;
-use OndraM\Env;
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
 
 class Circle extends AbstractCi
 {

--- a/src/Ci/Codeship.php
+++ b/src/Ci/Codeship.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OndraM\Ci;
+namespace OndraM\CiDetector\Ci;
 
-use OndraM\CiDetector;
-use OndraM\Env;
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
 
 class Codeship extends AbstractCi
 {

--- a/src/Ci/GitLab.php
+++ b/src/Ci/GitLab.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OndraM\Ci;
+namespace OndraM\CiDetector\Ci;
 
-use OndraM\CiDetector;
-use OndraM\Env;
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
 
 class GitLab extends AbstractCi
 {

--- a/src/Ci/Jenkins.php
+++ b/src/Ci/Jenkins.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OndraM\Ci;
+namespace OndraM\CiDetector\Ci;
 
-use OndraM\CiDetector;
-use OndraM\Env;
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
 
 class Jenkins extends AbstractCi
 {

--- a/src/Ci/TeamCity.php
+++ b/src/Ci/TeamCity.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OndraM\Ci;
+namespace OndraM\CiDetector\Ci;
 
-use OndraM\CiDetector;
-use OndraM\Env;
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
 
 class TeamCity extends AbstractCi
 {

--- a/src/Ci/Travis.php
+++ b/src/Ci/Travis.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OndraM\Ci;
+namespace OndraM\CiDetector\Ci;
 
-use OndraM\CiDetector;
-use OndraM\Env;
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
 
 class Travis extends AbstractCi
 {

--- a/src/CiDetector.php
+++ b/src/CiDetector.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace OndraM;
+namespace OndraM\CiDetector;
 
-use OndraM\Ci\AbstractCi;
+use OndraM\CiDetector\Ci\AbstractCi;
 
 /**
  * Unified way to get environment variables from current continuous integration server

--- a/src/Env.php
+++ b/src/Env.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OndraM;
+namespace OndraM\CiDetector;
 
 /**
  * Encapsulate access to the environment variables

--- a/tests/phpt/CiDetector_Bamboo.phpt
+++ b/tests/phpt/CiDetector_Bamboo.phpt
@@ -38,7 +38,7 @@ bamboo_shortJobKey=JOB1
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$ci = (new OndraM\CiDetector())->detect();
+$ci = (new OndraM\CiDetector\CiDetector())->detect();
 echo "Class:\n";
 var_dump(get_class($ci));
 echo "CI name:\n";
@@ -56,7 +56,7 @@ var_dump($ci->getRepositoryUrl());
 
 --EXPECT--
 Class:
-string(16) "OndraM\Ci\Bamboo"
+string(27) "OndraM\CiDetector\Ci\Bamboo"
 CI name:
 string(6) "Bamboo"
 Build number:

--- a/tests/phpt/CiDetector_Circle.phpt
+++ b/tests/phpt/CiDetector_Circle.phpt
@@ -28,7 +28,7 @@ CIRCLE_PROJECT_REPONAME=ci-detector
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$ci = (new OndraM\CiDetector())->detect();
+$ci = (new OndraM\CiDetector\CiDetector())->detect();
 echo "Class:\n";
 var_dump(get_class($ci));
 echo "CI name:\n";
@@ -46,7 +46,7 @@ var_dump($ci->getRepositoryUrl());
 
 --EXPECT--
 Class:
-string(16) "OndraM\Ci\Circle"
+string(27) "OndraM\CiDetector\Ci\Circle"
 CI name:
 string(8) "CircleCI"
 Build number:

--- a/tests/phpt/CiDetector_Codeship.phpt
+++ b/tests/phpt/CiDetector_Codeship.phpt
@@ -24,7 +24,7 @@ CI_BUILD_NUMBER=17594878
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$ci = (new OndraM\CiDetector())->detect();
+$ci = (new OndraM\CiDetector\CiDetector())->detect();
 echo "Class:\n";
 var_dump(get_class($ci));
 echo "CI name:\n";
@@ -42,7 +42,7 @@ var_dump($ci->getRepositoryUrl());
 
 --EXPECT--
 Class:
-string(18) "OndraM\Ci\Codeship"
+string(29) "OndraM\CiDetector\Ci\Codeship"
 CI name:
 string(8) "Codeship"
 Build number:

--- a/tests/phpt/CiDetector_GitLab.phpt
+++ b/tests/phpt/CiDetector_GitLab.phpt
@@ -37,7 +37,7 @@ PHP_VERSION=7.0.10
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$ci = (new OndraM\CiDetector())->detect();
+$ci = (new OndraM\CiDetector\CiDetector())->detect();
 echo "Class:\n";
 var_dump(get_class($ci));
 echo "CI name:\n";
@@ -55,7 +55,7 @@ var_dump($ci->getRepositoryUrl());
 
 --EXPECT--
 Class:
-string(16) "OndraM\Ci\GitLab"
+string(27) "OndraM\CiDetector\Ci\GitLab"
 CI name:
 string(6) "GitLab"
 Build number:

--- a/tests/phpt/CiDetector_Jenkins.phpt
+++ b/tests/phpt/CiDetector_Jenkins.phpt
@@ -24,7 +24,7 @@ BUILD_NUMBER=1337
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$ci = (new OndraM\CiDetector())->detect();
+$ci = (new OndraM\CiDetector\CiDetector())->detect();
 echo "Class:\n";
 var_dump(get_class($ci));
 echo "CI name:\n";
@@ -42,7 +42,7 @@ var_dump($ci->getRepositoryUrl());
 
 --EXPECT--
 Class:
-string(17) "OndraM\Ci\Jenkins"
+string(28) "OndraM\CiDetector\Ci\Jenkins"
 CI name:
 string(7) "Jenkins"
 Build number:

--- a/tests/phpt/CiDetector_TeamCity.phpt
+++ b/tests/phpt/CiDetector_TeamCity.phpt
@@ -21,7 +21,7 @@ TEAMCITY_PROCESS_FLOW_ID=376437994027122
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$ci = (new OndraM\CiDetector())->detect();
+$ci = (new OndraM\CiDetector\CiDetector())->detect();
 echo "Class:\n";
 var_dump(get_class($ci));
 echo "CI name:\n";
@@ -39,7 +39,7 @@ var_dump($ci->getRepositoryUrl());
 
 --EXPECT--
 Class:
-string(18) "OndraM\Ci\TeamCity"
+string(29) "OndraM\CiDetector\Ci\TeamCity"
 CI name:
 string(8) "TeamCity"
 Build number:

--- a/tests/phpt/CiDetector_Travis.phpt
+++ b/tests/phpt/CiDetector_Travis.phpt
@@ -28,7 +28,7 @@ TRAVIS_TAG=tag
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$ci = (new OndraM\CiDetector())->detect();
+$ci = (new OndraM\CiDetector\CiDetector())->detect();
 echo "Class:\n";
 var_dump(get_class($ci));
 echo "CI name:\n";
@@ -46,7 +46,7 @@ var_dump($ci->getRepositoryUrl());
 
 --EXPECT--
 Class:
-string(16) "OndraM\Ci\Travis"
+string(27) "OndraM\CiDetector\Ci\Travis"
 CI name:
 string(9) "Travis CI"
 Build number:

--- a/tests/phpt/CiDetector_TravisPullRequest.phpt
+++ b/tests/phpt/CiDetector_TravisPullRequest.phpt
@@ -29,7 +29,7 @@ TRAVIS_PULL_REQUEST_BRANCH=test-travis-branch
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$ci = (new OndraM\CiDetector())->detect();
+$ci = (new OndraM\CiDetector\CiDetector())->detect();
 var_dump($ci->getGitBranch());
 
 --EXPECT--

--- a/tests/phpt/CiDetector_ci_not_detected.phpt
+++ b/tests/phpt/CiDetector_ci_not_detected.phpt
@@ -8,7 +8,7 @@ Return false if CI server is not detected
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-var_dump((new OndraM\CiDetector())->detect());
+var_dump((new OndraM\CiDetector\CiDetector())->detect());
 
 --EXPECT--
 bool(false)

--- a/tests/phpt/Env.phpt
+++ b/tests/phpt/Env.phpt
@@ -8,7 +8,7 @@ FOO=bar
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$env = new OndraM\Env();
+$env = new OndraM\CiDetector\Env();
 
 var_dump($env->get('FOO'));
 var_dump($env->get('NOT_EXISTING'));


### PR DESCRIPTION
To make it more organized.