### PR TITLE
Fix AppVeyor build URL

### DIFF
--- a/src/Ci/AppVeyor.php
+++ b/src/Ci/AppVeyor.php
@@ -25,11 +25,11 @@ class AppVeyor extends AbstractCi
     public function getBuildUrl(): string
     {
         return sprintf(
-            '%s/project/%s/%s/build/%s',
+            '%s/project/%s/%s/builds/%s',
             $this->env->get('APPVEYOR_URL'),
             $this->env->get('APPVEYOR_ACCOUNT_NAME'),
             $this->env->get('APPVEYOR_PROJECT_SLUG'),
-            $this->env->get('APPVEYOR_BUILD_VERSION')
+            $this->env->get('APPVEYOR_BUILD_ID')
         );
     }
 

--- a/tests/phpt/Ci/CiDetector_AppVeyor.phpt
+++ b/tests/phpt/Ci/CiDetector_AppVeyor.phpt
@@ -72,7 +72,7 @@ string(8) "AppVeyor"
 Build number:
 string(2) "37"
 Build url:
-string(63) "https://ci.appveyor.com/project/OndraM/ci-detector/build/1.3.37"
+string(65) "https://ci.appveyor.com/project/OndraM/ci-detector/builds/8791806"
 Git commit:
 string(40) "11cc783de14cf438a41a60af7cd148a43da74cce"
 Git branch:


### PR DESCRIPTION
Last part is the build ID, not the build version