### PR TITLE
Enhancement: Allow injecting environment

### DIFF
--- a/src/CiDetector.php
+++ b/src/CiDetector.php
@@ -23,6 +23,23 @@ class CiDetector
     public const CI_TEAMCITY = 'TeamCity';
     public const CI_TRAVIS = 'Travis CI';
 
+    /** @var Env */
+    private $environment;
+
+    public function __construct()
+    {
+        $this->environment = new Env();
+    }
+
+    public static function fromEnvironment(Env $environment): self
+    {
+        $detector = new self();
+
+        $detector->environment = $environment;
+
+        return $detector;
+    }
+
     /**
      * Is current environment an recognized CI server?
      */
@@ -72,12 +89,11 @@ class CiDetector
 
     protected function detectCurrentCiServer(): ?CiInterface
     {
-        $env = new Env();
         $ciServers = $this->getCiServers();
 
         foreach ($ciServers as $ciClass) {
-            if (call_user_func([$ciClass, 'isDetected'], $env)) {
-                return new $ciClass($env);
+            if (call_user_func([$ciClass, 'isDetected'], $this->environment)) {
+                return new $ciClass($this->environment);
             }
         }
 

--- a/tests/CiDetectorTest.php
+++ b/tests/CiDetectorTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace OndraM\CiDetector\Ci\Tests;
+
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
+use OndraM\CiDetector\Exception\CiNotDetectedException;
+use PHPUnit\Framework\TestCase;
+
+final class CiDetectorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldReturnFalseWhenEnvironmentDoesNotHaveAnyEnvironmentVariables(): void
+    {
+        $environment = self::createEmptyEnvironment();
+
+        $detector = CiDetector::fromEnvironment($environment);
+
+        $this->assertFalse($detector->isCiDetected());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldThrowExceptionWhenCreatingFromEnvironmentWhichIsNotACiServer(): void
+    {
+        $environment = self::createEmptyEnvironment();
+
+        $detector = CiDetector::fromEnvironment($environment);
+
+        $this->expectException(CiNotDetectedException::class);
+        $this->expectExceptionMessage('No CI server detected in current environment');
+
+        $detector->detect();
+    }
+
+    private static function createEmptyEnvironment(): Env
+    {
+        return new class() extends Env {
+            public function get(string $name)
+            {
+                return false;
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR

* [x] allows injecting an instance of `Env` when constructing a `CiDetector`

Related to https://github.com/infection/infection/pull/939.

💁‍♂ This would make it possible to use it `CiDetector` as a collaborator, without the need to set up environment variables for tests.