### PR TITLE
Enhancement: Enable and configure phpdoc_line_span fixer

### DIFF
--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -1,5 +1,8 @@
 imports:
     - { resource: '%vendor_dir%/lmc/coding-standard/easy-coding-standard.yaml' }
 services:
+    PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer:
+        property: single
+
     PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer:
         style: annotation


### PR DESCRIPTION
This PR

* [x] enables and configures the `phpdoc_line_span` fixer

Follows https://github.com/OndraM/ci-detector/pull/55#discussion_r384225099.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.1#usage:


>**phpdoc_line_span**
>
>Changes doc blocks from single to multi line, or reversed. Works for class constants, properties and methods only.
>
>Configuration options:
>
>* `const` (`'multi'`, `'single'`): whether `const` blocks should be single or multi line; defaults to `'multi'`
>* method (`'multi'`, `'single'`): whether method doc blocks should be single or multi line; defaults to `'multi'`
>* `property` (`'multi'`, `'single'`): whether property doc blocks should be single or multi line; defaults to `'multi'`
