### PR TITLE
Fix: Ignore files not needed for consumption

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+/.github/                   export-ignore
+/tests/                     export-ignore
+/.appveyor.yml              export-ignore
+/.gitattributes             export-ignore
+/.gitignore                 export-ignore
+/.travis.yml                export-ignore
+/circle.yml                 export-ignore
+/dump-current.php           export-ignore
+/easy-coding-standard.yaml  export-ignore
+/phpstan.neon               export-ignore
+/phpunit.xml.dist           export-ignore


### PR DESCRIPTION
This PR

* [x] ignores files not needed for consumption of package

💁‍♂ For reference, see https://git-scm.com/docs/gitattributes.