### PR TITLE
Allow fromEnvironment to be used form a child class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ## Unreleased
 - Add AWS CodeBuild detection support.
+- Allow late static binding in `CiDetector::fromEnvironment()` when inheriting the class.
 
 ## 3.3.0 - 2020-03-06
-- Allow injecting instance of `Env` into `CiDetector` (useful for environment mocking in unit tests).
+- Allow injecting instance of `Env` using `CiDetector::fromEnvironment()` (useful for environment mocking in unit tests).
 
 ## 3.2.0 - 2020-02-18
 - Add GitHub Actions detection support.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,10 @@
 parameters:
     ignoreErrors:
         - '/Parameter \#1 \$function of function call_user_func expects callable/'
+
+        # TODO: should be solved in next major version by declaring CiDetector final
+        - message: '#Unsafe usage of new static\(\)#'
+          path: 'src/CiDetector.php'
     level: 7
     paths:
         - src/

--- a/src/CiDetector.php
+++ b/src/CiDetector.php
@@ -34,11 +34,7 @@ class CiDetector
 
     public static function fromEnvironment(Env $environment): self
     {
-        $detector = new self();
-
-        $detector->environment = $environment;
-
-        return $detector;
+        return new static($environment);
     }
 
     /**

--- a/src/CiDetector.php
+++ b/src/CiDetector.php
@@ -34,7 +34,11 @@ class CiDetector
 
     public static function fromEnvironment(Env $environment): self
     {
-        return new static($environment);
+        $detector = new static();
+
+        $detector->environment = $environment;
+
+        return $detector;
     }
 
     /**


### PR DESCRIPTION
Replace `self` to `static` which allows late static binding to kick in, useful when inheriting the class.

Also note that not passing `Env` in the constructor instead of instantiating really makes it hard to extend