### PR TITLE
Fix tests (do not let xdebug override var_dump)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,6 +31,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl
           coverage: xdebug
+          ini-values: xdebug.overload_var_dump=0
 
       - name: Install dependencies
         run: composer update --no-interaction ${{ matrix.dependencies }}

--- a/.travis.php.ini
+++ b/.travis.php.ini
@@ -1,0 +1,1 @@
+xdebug.overload_var_dump=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - travis_retry composer update --no-interaction
 
 before_script:
+  - phpenv config-add .travis.php.ini
   - env # list current environment variables
   - php dump-current.php
   - unset TRAVIS # Unset the variable to not interfere with tests


### PR DESCRIPTION
New Xdebug default settings adds file name before var_dump output, which then differs with expected output and breaks our phpt tests.