### PR TITLE
Build only main branch on push, not PR pushes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,8 +1,10 @@
 name: Tests and linting
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
   schedule:
     - cron:  '0 3 * * *'
 


### PR DESCRIPTION
Avoids the situation where the same branch is built twice.