### PR TITLE
Update tests.yaml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: Submit coverage to Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NO_COLOR: 'true'
         run: |
           composer global require php-coveralls/php-coveralls:^2.4.2 --ignore-platform-req=php
           ~/.composer/vendor/bin/php-coveralls --coverage_clover=./build/logs/clover.xml -v

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export GITHUB_ACTIONS=true # Set it back so that php-coveralls properly detects Github Actions
-          composer global require twinh/php-coveralls --ignore-platform-req=php
+          composer global require php-coveralls/php-coveralls --ignore-platform-req=php
           ~/.composer/vendor/bin/php-coveralls --coverage_clover=./build/logs/clover.xml -v
 
   codestyle:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,8 +16,6 @@ jobs:
         dependencies: ['']
         xdebug-ini-values: ['xdebug.overload_var_dump=0']
         include:
-          # Run lowest dependencies only on PHP 7.1
-          - { php-versions: '7.1', dependencies: '--prefer-lowest' }
           - { php-versions: '8.0', dependencies: '--ignore-platform-req=php', xdebug-ini-values: '' }
 
     name: PHP ${{ matrix.php-versions }} ${{ matrix.dependencies }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,15 +45,15 @@ jobs:
 
       - name: Run tests
         run: |
-          unset GITHUB_ACTIONS
-          vendor/bin/phpunit --colors=always --coverage-clover build/logs/clover.xml
+          (unset GITHUB_ACTIONS
+          vendor/bin/phpunit --colors=always --coverage-clover build/logs/clover.xml)
 
       - name: Submit coverage to Coveralls
+        continue-on-error: true
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          export GITHUB_ACTIONS=true # Set it back so that php-coveralls properly detects Github Actions
-          composer global require php-coveralls/php-coveralls --ignore-platform-req=php
+          composer global require php-coveralls/php-coveralls:^2.4.2 --ignore-platform-req=php
           ~/.composer/vendor/bin/php-coveralls --coverage_clover=./build/logs/clover.xml -v
 
   codestyle:
@@ -63,7 +63,7 @@ jobs:
         - uses: actions/checkout@v2
 
         - name: Setup PHP
-          uses: shivammathur/setup-php@v1
+          uses: shivammathur/setup-php@v2
           with:
             php-version: '7.4'
             extensions: mbstring, intl

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,6 @@ jobs:
           vendor/bin/phpunit --colors=always --coverage-clover build/logs/clover.xml)
 
       - name: Submit coverage to Coveralls
-        continue-on-error: true
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NO_COLOR: 'true'
         run: |
-          composer global require php-coveralls/php-coveralls:^2.4.2 --ignore-platform-req=php
+          composer global require php-coveralls/php-coveralls:^2.4.2
           ~/.composer/vendor/bin/php-coveralls --coverage_clover=./build/logs/clover.xml -v
 
   codestyle:


### PR DESCRIPTION
- [x] Previously used version got merged into `php-coveralls/php-coveralls`. Use that.
- [x] This library does not have non-dev dependencies, therefore it makes no sense to test with `--prefer-lowest`.
- [x] Add Symfony-related PHP 7.1 workaround