### PR TITLE
Temporarily lock PHP on Appveyor to 7.4

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ branches:
 clone_folder: C:\projects\ci-detector
 
 cache:
-  - C:\tools\php71 -> appveyor.yml
+  - C:\tools\php -> appveyor.yml
 
 init:
  - SET PHP=1
@@ -19,7 +19,8 @@ init:
 install:
   - IF EXIST c:\tools\php (SET PHP=0)
   - IF %PHP%==1 cinst -y OpenSSL.Light
-  - IF %PHP%==1 cinst -y php --params "/InstallDir:C:\tools\php" # we could use -version to specify exact version, but we rather use the latest available
+  # TODO: remove -version and use the latest PHP (after https://github.com/lmc-eu/php-coding-standard/issues/41 is fixed)
+  - IF %PHP%==1 cinst -y php -version 7.4.13 --params "/InstallDir:C:\tools\php" # we could use -version to specify exact version, but we rather use the latest available
   - cd C:\tools\php
   - IF %PHP%==1 copy php.ini-production php.ini /Y
   - IF %PHP%==1 echo extension_dir=ext >> php.ini


### PR DESCRIPTION
Until https://github.com/lmc-eu/php-coding-standard/issues/41 is done.