### PR TITLE
Head branch retrieval support

### DIFF
--- a/src/Ci/AppVeyor.php
+++ b/src/Ci/AppVeyor.php
@@ -55,6 +55,11 @@ class AppVeyor extends AbstractCi
         return $prBranch;
     }
 
+    public function getTargetBranch(): string
+    {
+        return $this->env->getString('APPVEYOR_REPO_BRANCH');
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('APPVEYOR_REPO_NAME');

--- a/src/Ci/AwsCodeBuild.php
+++ b/src/Ci/AwsCodeBuild.php
@@ -47,6 +47,11 @@ class AwsCodeBuild extends AbstractCi
         return preg_replace('~^refs/heads/~', '', $gitReference) ?? '';
     }
 
+    public function getTargetBranch(): string
+    {
+        return '';  // unsupported
+    }
+
     public function getRepositoryName(): string
     {
         return ''; // unsupported

--- a/src/Ci/AzurePipelines.php
+++ b/src/Ci/AzurePipelines.php
@@ -54,6 +54,11 @@ class AzurePipelines extends AbstractCi
         return $this->env->getString('SYSTEM_PULLREQUEST_SOURCEBRANCH');
     }
 
+    public function getTargetBranch(): string
+    {
+        return $this->env->getString('SYSTEM_PULLREQUEST_TARGETBRANCH');
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('BUILD_REPOSITORY_NAME');

--- a/src/Ci/Bamboo.php
+++ b/src/Ci/Bamboo.php
@@ -49,6 +49,11 @@ class Bamboo extends AbstractCi
         return $prBranch;
     }
 
+    public function getTargetBranch(): string
+    {
+        return $this->env->getString('bamboo_repository_pr_targetBranch');
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('bamboo_planRepository_name');

--- a/src/Ci/BitbucketPipelines.php
+++ b/src/Ci/BitbucketPipelines.php
@@ -47,6 +47,11 @@ class BitbucketPipelines extends AbstractCi
         return $this->env->getString('BITBUCKET_BRANCH');
     }
 
+    public function getTargetBranch(): string
+    {
+        return $this->env->getString('BITBUCKET_PR_DESTINATION_BRANCH');
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('BITBUCKET_REPO_FULL_NAME');

--- a/src/Ci/Buddy.php
+++ b/src/Ci/Buddy.php
@@ -49,6 +49,11 @@ class Buddy extends AbstractCi
         return $prBranch;
     }
 
+    public function getTargetBranch(): string
+    {
+        return $this->env->getString('BUDDY_EXECUTION_PULL_REQUEST_BASE_BRANCH');
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('BUDDY_REPO_SLUG');

--- a/src/Ci/CiInterface.php
+++ b/src/Ci/CiInterface.php
@@ -48,6 +48,11 @@ interface CiInterface
     public function getGitBranch(): string;
 
     /**
+     * Get name of the target branch of a pull request.
+     */
+    public function getTargetBranch(): string;
+
+    /**
      * Get name of the git repository which is being built.
      *
      * This is usually in form "user/repository", for example "OndraM/ci-detector".

--- a/src/Ci/Circle.php
+++ b/src/Ci/Circle.php
@@ -43,6 +43,11 @@ class Circle extends AbstractCi
         return $this->env->getString('CIRCLE_BRANCH');
     }
 
+    public function getTargetBranch(): string
+    {
+        return ''; // unsupported
+    }
+
     public function getRepositoryName(): string
     {
         return sprintf(

--- a/src/Ci/Codeship.php
+++ b/src/Ci/Codeship.php
@@ -43,6 +43,11 @@ class Codeship extends AbstractCi
         return $this->env->getString('CI_BRANCH');
     }
 
+    public function getTargetBranch(): string
+    {
+        return ''; // unsupported
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('CI_REPO_NAME');

--- a/src/Ci/Continuousphp.php
+++ b/src/Ci/Continuousphp.php
@@ -45,6 +45,11 @@ class Continuousphp extends AbstractCi
         return preg_replace('~^refs/heads/~', '', $gitReference) ?? '';
     }
 
+    public function getTargetBranch(): string
+    {
+        return ''; // unsupported
+    }
+
     public function getRepositoryName(): string
     {
         return ''; // unsupported

--- a/src/Ci/Drone.php
+++ b/src/Ci/Drone.php
@@ -43,6 +43,11 @@ class Drone extends AbstractCi
         return $this->env->getString('DRONE_COMMIT_BRANCH');
     }
 
+    public function getTargetBranch(): string
+    {
+        return $this->env->getString('DRONE_TARGET_BRANCH');
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('DRONE_REPO');

--- a/src/Ci/GitHubActions.php
+++ b/src/Ci/GitHubActions.php
@@ -58,6 +58,11 @@ class GitHubActions extends AbstractCi
         return $prBranch;
     }
 
+    public function getTargetBranch(): string
+    {
+        return $this->env->getString('GITHUB_BASE_REF');
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('GITHUB_REPOSITORY');

--- a/src/Ci/GitLab.php
+++ b/src/Ci/GitLab.php
@@ -52,6 +52,13 @@ class GitLab extends AbstractCi
             : $this->env->getString('CI_BUILD_REF_NAME');
     }
 
+    public function getTargetBranch(): string
+    {
+        return !empty($this->env->getString('CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME'))
+            ? $this->env->getString('CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME')
+            : $this->env->getString('CI_MERGE_REQUEST_TARGET_BRANCH_NAME');
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('CI_PROJECT_PATH');

--- a/src/Ci/Jenkins.php
+++ b/src/Ci/Jenkins.php
@@ -43,6 +43,11 @@ class Jenkins extends AbstractCi
         return $this->env->getString('GIT_BRANCH');
     }
 
+    public function getTargetBranch(): string
+    {
+        return ''; // unsupported
+    }
+
     public function getRepositoryName(): string
     {
         return ''; // unsupported

--- a/src/Ci/TeamCity.php
+++ b/src/Ci/TeamCity.php
@@ -43,6 +43,11 @@ class TeamCity extends AbstractCi
         return ''; // unsupported
     }
 
+    public function getTargetBranch(): string
+    {
+        return ''; // unsupported
+    }
+
     public function getRepositoryName(): string
     {
         return ''; // unsupported

--- a/src/Ci/Travis.php
+++ b/src/Ci/Travis.php
@@ -54,6 +54,11 @@ class Travis extends AbstractCi
         return $this->env->getString('TRAVIS_PULL_REQUEST_BRANCH');
     }
 
+    public function getTargetBranch(): string
+    {
+        return $this->env->getString('TRAVIS_BRANCH');
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('TRAVIS_REPO_SLUG');

--- a/src/Ci/Wercker.php
+++ b/src/Ci/Wercker.php
@@ -43,6 +43,11 @@ class Wercker extends AbstractCi
         return $this->env->getString('WERCKER_GIT_BRANCH');
     }
 
+    public function getTargetBranch(): string
+    {
+        return ''; // unsupported
+    }
+
     public function getRepositoryName(): string
     {
         return $this->env->getString('WERCKER_GIT_OWNER') . '/' . $this->env->getString('WERCKER_GIT_REPOSITORY');

--- a/tests/phpt/Ci/CiDetector_AppVeyorPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_AppVeyorPullRequest.phpt
@@ -53,9 +53,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(17) "feature/pr-branch"
+Target branch:
+string(4) "main"

--- a/tests/phpt/Ci/CiDetector_AwsCodeBuildPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_AwsCodeBuildPullRequest.phpt
@@ -62,9 +62,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(14) "test/pr-branch"
+Target branch:
+string(0) ""

--- a/tests/phpt/Ci/CiDetector_AzurePipelinesPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_AzurePipelinesPullRequest.phpt
@@ -171,9 +171,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(23) "feature/azure-pipelines"
+Target branch:
+string(4) "main"

--- a/tests/phpt/Ci/CiDetector_BambooPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_BambooPullRequest.phpt
@@ -74,9 +74,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(9) "pr-branch"
+Target branch:
+string(4) "main"

--- a/tests/phpt/Ci/CiDetector_BitbucketPipelinesPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_BitbucketPipelinesPullRequest.phpt
@@ -35,9 +35,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(17) "feature/bitbucket"
+Target branch:
+string(4) "main"

--- a/tests/phpt/Ci/CiDetector_BuddyPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_BuddyPullRequest.phpt
@@ -58,9 +58,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(17) "feature/pr-branch"
+Target branch:
+string(4) "main"

--- a/tests/phpt/Ci/CiDetector_CirclePullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_CirclePullRequest.phpt
@@ -32,9 +32,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(13) "test-circleci"
+Target branch:
+string(0) ""

--- a/tests/phpt/Ci/CiDetector_CodeshipPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_CodeshipPullRequest.phpt
@@ -29,9 +29,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(13) "test-codeship"
+Target branch:
+string(0) ""

--- a/tests/phpt/Ci/CiDetector_ContinuousphpPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_ContinuousphpPullRequest.phpt
@@ -52,9 +52,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(25) "test-continuousphp-branch"
+Target branch:
+string(0) ""

--- a/tests/phpt/Ci/CiDetector_DronePullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_DronePullRequest.phpt
@@ -92,9 +92,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(10) "test-drone"
+Target branch:
+string(0) ""

--- a/tests/phpt/Ci/CiDetector_GitHubActionsPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_GitHubActionsPullRequest.phpt
@@ -88,9 +88,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(17) "feature/pr-branch"
+Target branch:
+string(4) "main"

--- a/tests/phpt/Ci/CiDetector_GitLabExternalPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_GitLabExternalPullRequest.phpt
@@ -10,6 +10,7 @@ CI_BUILD_REF=1e50d546a67287e3111707283eb28bfff50584a9
 CI_BUILD_REPO=https://gitlab-ci-token:xxxxxx@gitlab.com/foo/bar.git
 CI_BUILD_STAGE=test
 CI_EXTERNAL_PULL_REQUEST_IID=43
+CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME=main
 CI_PIPELINE_ID=3993609
 CI_PROJECT_DIR=/builds/OndraM/ci-detector
 CI_PROJECT_ID=1545369
@@ -43,9 +44,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(11) "test-gitlab"
+Target branch:
+string(4) "main"

--- a/tests/phpt/Ci/CiDetector_GitLabMergeRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_GitLabMergeRequest.phpt
@@ -10,6 +10,7 @@ CI_BUILD_REF=1e50d546a67287e3111707283eb28bfff50584a9
 CI_BUILD_REPO=https://gitlab-ci-token:xxxxxx@gitlab.com/foo/bar.git
 CI_BUILD_STAGE=test
 CI_MERGE_REQUEST_ID=43
+CI_MERGE_REQUEST_TARGET_BRANCH_NAME=main
 CI_PIPELINE_ID=3993609
 CI_PROJECT_DIR=/builds/OndraM/ci-detector
 CI_PROJECT_ID=1545369
@@ -43,9 +44,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(11) "test-gitlab"
+Target branch:
+string(4) "main"

--- a/tests/phpt/Ci/CiDetector_Jenkins.phpt
+++ b/tests/phpt/Ci/CiDetector_Jenkins.phpt
@@ -42,6 +42,8 @@ echo "Git commit:\n";
 var_dump($ci->getGitCommit());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 echo "Repository name:\n";
 var_dump($ci->getRepositoryName());
 echo "Repository url:\n";
@@ -64,6 +66,8 @@ Git commit:
 string(40) "11cc783de14cf438a41a60af7cd148a43da74ccd"
 Git branch:
 string(17) "origin/branchname"
+Target branch:
+string(0) ""
 Repository name:
 string(0) ""
 Repository url:

--- a/tests/phpt/Ci/CiDetector_TeamCity.phpt
+++ b/tests/phpt/Ci/CiDetector_TeamCity.phpt
@@ -39,6 +39,8 @@ echo "Git commit:\n";
 var_dump($ci->getGitCommit());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 echo "Repository name:\n";
 var_dump($ci->getRepositoryName());
 echo "Repository url:\n";
@@ -60,6 +62,8 @@ string(0) ""
 Git commit:
 string(40) "1ee546f280c093f1e24ecc149db4a0a100c8d609"
 Git branch:
+string(0) ""
+Target branch:
 string(0) ""
 Repository name:
 string(0) ""

--- a/tests/phpt/Ci/CiDetector_TravisPullRequest.phpt
+++ b/tests/phpt/Ci/CiDetector_TravisPullRequest.phpt
@@ -142,9 +142,13 @@ echo "Is pull request:\n";
 var_dump($ci->isPullRequest()->describe());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 
 --EXPECT--
 Is pull request:
 string(3) "Yes"
 Git branch:
 string(17) "feature/pr-branch"
+Target branch:
+string(4) "main"

--- a/tests/phpt/Ci/CiDetector_Wercker.phpt
+++ b/tests/phpt/Ci/CiDetector_Wercker.phpt
@@ -77,6 +77,8 @@ echo "Git commit:\n";
 var_dump($ci->getGitCommit());
 echo "Git branch:\n";
 var_dump($ci->getGitBranch());
+echo "Target branch:\n";
+var_dump($ci->getTargetBranch());
 echo "Repository name:\n";
 var_dump($ci->getRepositoryName());
 echo "Repository url:\n";
@@ -99,6 +101,8 @@ Git commit:
 string(40) "929d637c83efed51a6a0f210aed89f1adb874401"
 Git branch:
 string(12) "test-wercker"
+Target branch:
+string(0) ""
 Repository name:
 string(18) "OndraM/ci-detector"
 Repository url:


### PR DESCRIPTION
Fixes #82

This is a BC break, hence it is time for a next major version.

Implementation status:

- [x] AppVeyor `APPVEYOR_REPO_BRANCH` [(ref)](https://www.appveyor.com/docs/environment-variables/)
- [x] AWS CodeBuild - [seems to be none](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html)
- [x] AzurePipelines `SYSTEM_PULLREQUEST_TARGETBRANCH`
- [x] Bamboo `bamboo.repository.pr.targetBranch` [(ref)](https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html#Bamboovariables-Build-specificvariables)
- [x] Bitbucket Pipelines `BITBUCKET_PR_DESTINATION_BRANCH`
- [x] Buddy `BUDDY_EXECUTION_PULL_REQUEST_BASE_BRANCH`
- [x] CircleCI - [There's none.](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables)
- [x] Codeship [(there's none)](https://docs.cloudbees.com/docs/cloudbees-codeship/latest/pro-builds-and-configuration/environment-variables#_default_environment_variables)
- [x] continuousphp - [there's none](https://doc.continuousphp.com/environment-variables/#built-in-environment-variables)
- [x] codefresh.io `CF_PULL_REQUEST_TARGET` (CF is not yet supported here)
- [x] drone `DRONE_TARGET_BRANCH`
- [x] GitHub Actions `GITHUB_BASE_REF`
- [x] GitLab, either `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` or `CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME`
- [x] Jenkins - [seems to be none](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables)
- [x] TeamCity - [None found.](https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Branch-Related+Parameters)
- [x] Travis CI `TRAVIS_BRANCH`
- [x] Wercker - [there's none](https://devcenter.wercker.com/administration/environment-variables/available-env-vars/).
