### PR TITLE
Allow simpler extension of CiDetector [BC break]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 - Add Azure DevOps Pipelines detection support.
+- Add `CiDetectorInterface` (extended by `CiDetector`) to allow simpler extension.
+- BC: Declare `CiDetector` constructor final.
 - Fix build URL detection on Travis (it always reported travis-ci.org URL, even if the build was on travis-ci.com).
 
 ## 3.5.1 - 2020-09-04

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,4 @@
 parameters:
-    ignoreErrors:
-        # TODO: should be solved in next major version by declaring CiDetector final
-        - message: '#Unsafe usage of new static\(\)#'
-          path: 'src/CiDetector.php'
     level: max
     paths:
         - src/

--- a/src/CiDetector.php
+++ b/src/CiDetector.php
@@ -8,7 +8,7 @@ use OndraM\CiDetector\Exception\CiNotDetectedException;
 /**
  * Unified way to get environment variables from current continuous integration server
  */
-class CiDetector
+class CiDetector implements CiDetectorInterface
 {
     public const CI_APPVEYOR = 'AppVeyor';
     public const CI_AWS_CODEBUILD = 'AWS CodeBuild';
@@ -30,7 +30,7 @@ class CiDetector
     /** @var Env */
     private $environment;
 
-    public function __construct()
+    final public function __construct()
     {
         $this->environment = new Env();
     }
@@ -44,9 +44,6 @@ class CiDetector
         return $detector;
     }
 
-    /**
-     * Is current environment an recognized CI server?
-     */
     public function isCiDetected(): bool
     {
         $ciServer = $this->detectCurrentCiServer();
@@ -54,11 +51,6 @@ class CiDetector
         return ($ciServer !== null);
     }
 
-    /**
-     * Detect current CI server and return instance of its settings
-     *
-     * @throws CiNotDetectedException
-     */
     public function detect(): CiInterface
     {
         $ciServer = $this->detectCurrentCiServer();

--- a/src/CiDetectorInterface.php
+++ b/src/CiDetectorInterface.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace OndraM\CiDetector;
+
+use OndraM\CiDetector\Ci\CiInterface;
+use OndraM\CiDetector\Exception\CiNotDetectedException;
+
+/**
+ * Unified way to get environment variables from current continuous integration server
+ */
+interface CiDetectorInterface
+{
+    /**
+     * Is current environment an recognized CI server?
+     */
+    public function isCiDetected(): bool;
+
+    /**
+     * Detect current CI server and return instance of its settings
+     *
+     * @throws CiNotDetectedException
+     */
+    public function detect(): CiInterface;
+}


### PR DESCRIPTION
Fixes #64 . *This is BC break*, because we change CiDetector to have final constructor.

Introduce new `CiDetectorInterface`, so that it can be easily extended by eg. decorator, like they do [in Infection](https://github.com/infection/infection/blob/master/src/CI/MemoizedCiDetector.php).