### PR TITLE
Describe all detected values in human-readable form

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 PHP library to detect continuous integration environment and to provide a unified interface to read the build information.
 
-The detection is based on environment variables injected to the build environment by each of CI
-server. However, these variables are named differently in each CI. This library contains adapter for each supported
-CI server, which handles these differences, so you don't have to, and you can make your scripts (and especially CLI tools)
-portable for multiple build environments.
+The detection is based on environment variables injected to the build environment by each CI
+server. However, these variables are named differently in each CI. This library contains adapters for many supported
+CI servers to handles these differences, so you don't have to, and you can make your scripts (and especially CLI tools)
+portable to multiple build environments.
 
 ## Supported continuous integration servers
 
@@ -85,6 +85,22 @@ if ($ciDetector->isCiDetected()) {  // Make sure we are on CI environment
     if ($ci->getCiName() === OndraM\CiDetector\CiDetector::CI_JENKINS) {
         echo 'Current CI server is Jenkins';
     }
+
+    // Describe all detected values in human-readable form:
+    print_r($ci->describe());
+    // Array
+    // (
+    //     [ci-name] => Travis CI
+    //     [build-number] => 35.1
+    //     [build-url] => https://travis-ci.org/OndraM/ci-detector/jobs/148395137
+    //     [commit] => fad3f7bdbf3515d1e9285b8aa80feeff74507bdd
+    //     [branch] => feature/foo-bar
+    //     [target-branch] => main
+    //     [repository-name] => OndraM/ci-detector
+    //     [repository-url] => 
+    //     [is-pull-request] => No
+    // )
+
 } else {
     echo 'This script is not run on CI server';
 }

--- a/src/Ci/AbstractCi.php
+++ b/src/Ci/AbstractCi.php
@@ -16,4 +16,19 @@ abstract class AbstractCi implements CiInterface
     {
         $this->env = $env;
     }
+
+    public function describe(): array
+    {
+        return [
+            'ci-name' => $this->getCiName(),
+            'build-number' => $this->getBuildNumber(),
+            'build-url' => $this->getBuildUrl(),
+            'commit' => $this->getCommit(),
+            'branch' => $this->getBranch(),
+            'target-branch' => $this->getTargetBranch(),
+            'repository-name' => $this->getRepositoryName(),
+            'repository-url' => $this->getRepositoryUrl(),
+            'is-pull-request' => $this->isPullRequest()->describe(),
+        ];
+    }
 }

--- a/src/Ci/CiInterface.php
+++ b/src/Ci/CiInterface.php
@@ -18,10 +18,11 @@ interface CiInterface
     public function getCiName(): string;
 
     /**
-     * Returned TrinaryLogic object's value will be true if the current build is from a pull/merge request,
-     * false if it not, and maybe if we can't determine it.
+     * Return key-value map of all detected properties in human-readable form.
+     *
+     * @return array<string, string>
      */
-    public function isPullRequest(): TrinaryLogic;
+    public function describe(): array;
 
     /**
      * Get number of this concrete build.
@@ -68,4 +69,10 @@ interface CiInterface
      * but may be a git ssh url like "ssh://git@bitbucket.org/OndraM/ci-detector".
      */
     public function getRepositoryUrl(): string;
+
+    /**
+     * Returned TrinaryLogic object's value will be true if the current build is from a pull/merge request,
+     * false if it not, and maybe if we can't determine it.
+     */
+    public function isPullRequest(): TrinaryLogic;
 }

--- a/tests/DescribeTest.php
+++ b/tests/DescribeTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace OndraM\CiDetector\Ci\Tests;
+
+use OndraM\CiDetector\Ci\AbstractCi;
+use OndraM\CiDetector\Env;
+use OndraM\CiDetector\TrinaryLogic;
+use PHPUnit\Framework\TestCase;
+
+final class DescribeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldDescribeCiServerTrue(): void
+    {
+        $ci = $this->createDummyCi();
+
+        $this->assertSame(
+            [
+                'ci-name' => 'Dummy CI',
+                'build-number' => 'build no. 1',
+                'build-url' => 'https://build.url',
+                'commit' => 'abcdef12',
+                'branch' => 'feature/branch',
+                'target-branch' => 'main',
+                'repository-name' => 'repository/name',
+                'repository-url' => 'https://repository.url',
+                'is-pull-request' => 'Yes',
+            ],
+            $ci->describe()
+        );
+    }
+
+    private function createDummyCi(): AbstractCi
+    {
+        return new class($this->createMock(Env::class)) extends AbstractCi {
+            public static function isDetected(Env $env): bool
+            {
+                return true;
+            }
+
+            public function getCiName(): string
+            {
+                return 'Dummy CI';
+            }
+
+            public function getBuildNumber(): string
+            {
+                return 'build no. 1';
+            }
+
+            public function getBuildUrl(): string
+            {
+                return 'https://build.url';
+            }
+
+            public function getCommit(): string
+            {
+                return 'abcdef12';
+            }
+
+            public function getBranch(): string
+            {
+                return 'feature/branch';
+            }
+
+            public function getTargetBranch(): string
+            {
+                return 'main';
+            }
+
+            public function getRepositoryName(): string
+            {
+                return 'repository/name';
+            }
+
+            public function getRepositoryUrl(): string
+            {
+                return 'https://repository.url';
+            }
+
+            public function isPullRequest(): TrinaryLogic
+            {
+                return TrinaryLogic::createFromBoolean(true);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Could be used for simple dump of all detected properties.

```php
$ci = $ciDetector->detect();
print_r($ci->describe());
```

```
[
    [ci-name] => Travis CI
    [build-number] => 33.3
    [build-url] => https://travis-ci.org/OndraM/ci-detector/jobs/148395000
    [commit] => abcdf7bdbf3515d1e9285b8aa80feeff74507bdd
    [branch] => feature/foo-bar
    [target-branch] => main
    [repository-name] => OndraM/ci-detector
    [repository-url] => https://github.com/OndraM/ci-detector/
    [is-pull-request] => Yes
]
```