### PR TITLE
Do not report target branch if not on pull request

### DIFF
--- a/src/Ci/AppVeyor.php
+++ b/src/Ci/AppVeyor.php
@@ -57,6 +57,10 @@ class AppVeyor extends AbstractCi
 
     public function getTargetBranch(): string
     {
+        if ($this->isPullRequest()->no()) {
+            return '';
+        }
+
         return $this->env->getString('APPVEYOR_REPO_BRANCH');
     }
 

--- a/src/Ci/Travis.php
+++ b/src/Ci/Travis.php
@@ -56,6 +56,10 @@ class Travis extends AbstractCi
 
     public function getTargetBranch(): string
     {
+        if ($this->isPullRequest()->no()) {
+            return '';
+        }
+
         return $this->env->getString('TRAVIS_BRANCH');
     }
 


### PR DESCRIPTION
For CI's which swap variables semantics in non-PR/PR build (AppVeyor and Travis) we should not report the current branch as target branch if the build is not a pull request.

Cc @sanmai 