### PR TITLE
Implement support for SourceHut CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Add SourceHut detection support.
 
 ## 4.0.0 - 2021-02-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These CI servers are currently recognized:
  - [GitHub Actions](https://github.com/features/actions)
  - [GitLab](https://about.gitlab.com/gitlab-ci/)
  - [Jenkins](https://www.jenkins.io/)
+ - [SourceHut](https://sourcehut.org/)
  - [TeamCity](https://www.jetbrains.com/teamcity/)
  - [Travis CI](https://travis-ci.org/)
  - [Wercker](https://devcenter.wercker.com/)
@@ -141,6 +142,7 @@ necessary environment variables, thus reading some information may be unsupporte
 | [GitHub Actions](https://github.com/features/actions)  | `CI_GITHUB_ACTIONS`  | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
 | [GitLab](https://about.gitlab.com/gitlab-ci/)          | `CI_GITLAB`          | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
 | [Jenkins](https://www.jenkins.io/)                     | `CI_JENKINS`         | ❌ | ✔ | ❌ | ❌ | ✔ | ✔ |
+| [SourceHut](https://sourcehut.org/)                    | `CI_SOURCEHUT`       | ✔ | ❌ | ❌ | ❌ | ❌ | ✔ |
 | [TeamCity](https://www.jetbrains.com/teamcity/)        | `CI_TEAMCITY`        | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | [Travis CI](https://travis-ci.org/)                    | `CI_TRAVIS`          | ✔ | ✔ | ✔ | ✔ | ❌ | ✔ |
 | [Wercker](https://devcenter.wercker.com/)              | `CI_WERCKER`         | ❌ | ✔ | ❌ | ✔ | ❌ | ✔ |

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "gitlab",
         "jenkins",
         "pipelines",
+        "sourcehut",
         "teamcity",
         "travis",
         "wercker"

--- a/src/Ci/SourceHut.php
+++ b/src/Ci/SourceHut.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace OndraM\CiDetector\Ci;
+
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
+use OndraM\CiDetector\TrinaryLogic;
+
+class SourceHut extends AbstractCi
+{
+    public static function isDetected(Env $env): bool
+    {
+        return $env->getString('CI_NAME') === 'sourcehut';
+    }
+
+    public function getCiName(): string
+    {
+        return CiDetector::CI_SOURCEHUT;
+    }
+
+    public function isPullRequest(): TrinaryLogic
+    {
+        return TrinaryLogic::createFromBoolean($this->env->getString('BUILD_REASON') === 'patchset');
+    }
+
+    public function getBuildNumber(): string
+    {
+        return $this->env->getString('JOB_ID');
+    }
+
+    public function getBuildUrl(): string
+    {
+        return $this->env->getString('JOB_URL');
+    }
+
+    public function getCommit(): string
+    {
+        return ''; // unsupported
+    }
+
+    public function getBranch(): string
+    {
+        return ''; // unsupported
+    }
+
+    public function getTargetBranch(): string
+    {
+        return '';  // unsupported
+    }
+
+    public function getRepositoryName(): string
+    {
+        return ''; // unsupported
+    }
+
+    public function getRepositoryUrl(): string
+    {
+        return ''; // unsupported
+    }
+}

--- a/src/CiDetector.php
+++ b/src/CiDetector.php
@@ -23,6 +23,7 @@ class CiDetector implements CiDetectorInterface
     public const CI_GITHUB_ACTIONS = 'GitHub Actions';
     public const CI_GITLAB = 'GitLab';
     public const CI_JENKINS = 'Jenkins';
+    public const CI_SOURCEHUT = 'SourceHut';
     public const CI_TEAMCITY = 'TeamCity';
     public const CI_TRAVIS = 'Travis CI';
     public const CI_WERCKER = 'Wercker';
@@ -81,6 +82,7 @@ class CiDetector implements CiDetectorInterface
             Ci\GitHubActions::class,
             Ci\GitLab::class,
             Ci\Jenkins::class,
+            Ci\SourceHut::class,
             Ci\TeamCity::class,
             Ci\Travis::class,
             Ci\Wercker::class,

--- a/tests/phpt/Ci/CiDetector_SourceHut.phpt
+++ b/tests/phpt/Ci/CiDetector_SourceHut.phpt
@@ -1,0 +1,50 @@
+--TEST--
+SourceHut: Detect properties
+
+--ENV--
+CI_NAME=sourcehut
+HOME=/home/build
+JOB_ID=484504
+JOB_URL=https://builds.sr.ht/~ancarda/job/484504
+LOGNAME=build
+MAIL=/var/mail/build
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+PWD=/home/build
+SHELL=/bin/sh
+SHLVL=2
+SSH_CLIENT=172.17.0.1 38618 22
+SSH_CONNECTION=172.17.0.1 38618 10.0.2.15 22
+SSH_TTY=/dev/pts/0
+TERM=xterm-256color
+USER=build
+
+--FILE--
+<?php
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+\OndraM\CiDetector\Ci\PropertiesPrinterHelper::printAllProperties();
+
+--EXPECT--
+Is CI detected:
+bool(true)
+Class:
+string(30) "OndraM\CiDetector\Ci\SourceHut"
+CI name:
+string(9) "SourceHut"
+Is pull request:
+string(2) "No"
+Build number:
+string(6) "484504"
+Build url:
+string(40) "https://builds.sr.ht/~ancarda/job/484504"
+Commit:
+string(0) ""
+Branch:
+string(0) ""
+Target branch:
+string(0) ""
+Repository name:
+string(0) ""
+Repository url:
+string(0) ""

--- a/tests/phpt/Ci/CiDetector_SourceHut_Patch.phpt
+++ b/tests/phpt/Ci/CiDetector_SourceHut_Patch.phpt
@@ -1,0 +1,38 @@
+--TEST--
+SourceHut: Detect properties of PR build
+
+--ENV--
+BUILD_REASON=patchset
+BUILD_SUBMITTER=hub.sr.ht
+CI_NAME=sourcehut
+HOME=/home/build
+JOB_ID=484505
+JOB_URL=https://builds.sr.ht/~ancarda/job/484505
+LOGNAME=build
+MAIL=/var/mail/build
+PATCHSET_ID=21996
+PATCHSET_URL=https://lists.sr.ht/~ancarda/dump-env/patches/21996
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+PWD=/home/build
+SHELL=/bin/sh
+SHLVL=2
+SSH_CLIENT=172.17.0.1 49854 22
+SSH_CONNECTION=172.17.0.1 49854 10.0.2.15 22
+SSH_TTY=/dev/pts/0
+TERM=xterm-256color
+USER=build
+
+--FILE--
+<?php
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+\OndraM\CiDetector\Ci\PropertiesPrinterHelper::printPullRequestProperties();
+
+--EXPECT--
+Is pull request:
+string(3) "Yes"
+Branch:
+string(0) ""
+Target branch:
+string(0) ""


### PR DESCRIPTION
This commit adds a basic detector for [SourceHut](https://sourcehut.org)'s [builds.sr.ht](https://builds.sr.ht) service.